### PR TITLE
chore: remove unused user param

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ import (
 
 func main() {
 	client := services.NewServicesClient(
-		kraftcloud.WithUser("user"),
 		kraftcloud.WithToken("token"),
 	)
 

--- a/examples/image/go.sum
+++ b/examples/image/go.sum
@@ -1,0 +1,2 @@
+sdk.kraft.cloud v0.2.0 h1:yeUZVaE1q9WpnYbGfv5gBhDOzH1BwIA/ArH2bGH5nJ4=
+sdk.kraft.cloud v0.2.0/go.mod h1:8nWpenBQzgMvXDr5iJv2azfDyBfxQhTuG/Lm0OWRG9s=

--- a/examples/image/list.go
+++ b/examples/image/list.go
@@ -17,16 +17,13 @@ import (
 
 // This demonstrates how to list images in your project.
 func main() {
-	user := os.Getenv("KRAFTCLOUD_USER")
 	token := os.Getenv("KRAFTCLOUD_TOKEN")
-
-	if user == "" || token == "" {
-		fmt.Println("Please set KRAFTCLOUD_USER and KRAFTCLOUD_TOKEN environment variables")
+	if token == "" {
+		fmt.Println("Please set KRAFTCLOUD_TOKEN environment variable")
 		return
 	}
 
 	client := image.NewImagesClient(
-		kraftcloud.WithUser(user),
 		kraftcloud.WithToken(token),
 	)
 	filter := make(map[string]interface{})

--- a/examples/instance/go.sum
+++ b/examples/instance/go.sum
@@ -8,3 +8,5 @@ github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+sdk.kraft.cloud v0.2.0 h1:yeUZVaE1q9WpnYbGfv5gBhDOzH1BwIA/ArH2bGH5nJ4=
+sdk.kraft.cloud v0.2.0/go.mod h1:8nWpenBQzgMvXDr5iJv2azfDyBfxQhTuG/Lm0OWRG9s=

--- a/examples/instance/main.go
+++ b/examples/instance/main.go
@@ -19,16 +19,13 @@ import (
 // Here, you'll learn how to create an instance and display its console output.
 // Subsequent actions include stopping and starting the instance, listing all instances in the project, and, ultimately, deleting the created instance.
 func main() {
-	user := os.Getenv("KRAFTCLOUD_USER")
 	token := os.Getenv("KRAFTCLOUD_TOKEN")
-
-	if user == "" || token == "" {
-		fmt.Println("Please set KRAFTCLOUD_USER and KRAFTCLOUD_TOKEN environment variables")
+	if token == "" {
+		fmt.Println("Please set KRAFTCLOUD_TOKEN environment variable")
 		return
 	}
 
 	apiClient := instance.NewInstancesClient(
-		kraftcloud.WithUser(user),
 		kraftcloud.WithToken(token),
 	)
 	ctx := context.Background()

--- a/options.go
+++ b/options.go
@@ -37,14 +37,6 @@ func NewDefaultOptions(opts ...Option) *Options {
 	return &options
 }
 
-// WithUser sets the username of the client connecting to KraftCloud.
-func WithUser(user string) Option {
-	return func(client *Options) error {
-		client.user = user
-		return nil
-	}
-}
-
 // WithToken sets the access token of the client connecting to KraftCloud.
 func WithToken(token string) Option {
 	return func(client *Options) error {


### PR DESCRIPTION
The client uses `token` as the bearer token. It no longer composes that token from `user + token` since #3, so the option can be removed.