### PR TITLE
feat!: return objects that carry raw response bodies

### DIFF
--- a/certificates/certificate_get_by_names.go
+++ b/certificates/certificate_get_by_names.go
@@ -17,7 +17,7 @@ import (
 )
 
 // GetByNames implements CertificatesService.
-func (c *client) GetByNames(ctx context.Context, names ...string) ([]GetResponseItem, error) {
+func (c *client) GetByNames(ctx context.Context, names ...string) (*kcclient.ServiceResponse[GetResponseItem], error) {
 	if len(names) == 0 {
 		return nil, errors.New("requires at least one name")
 	}
@@ -32,21 +32,10 @@ func (c *client) GetByNames(ctx context.Context, names ...string) ([]GetResponse
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[GetResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[GetResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/certificates/certificate_get_by_uuids.go
+++ b/certificates/certificate_get_by_uuids.go
@@ -17,7 +17,7 @@ import (
 )
 
 // GetByUUIDs implements CertificatesService.
-func (c *client) GetByUUIDs(ctx context.Context, uuids ...string) ([]GetResponseItem, error) {
+func (c *client) GetByUUIDs(ctx context.Context, uuids ...string) (*kcclient.ServiceResponse[GetResponseItem], error) {
 	if len(uuids) == 0 {
 		return nil, errors.New("requires at least one uuid")
 	}
@@ -32,21 +32,10 @@ func (c *client) GetByUUIDs(ctx context.Context, uuids ...string) ([]GetResponse
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[GetResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[GetResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/certificates/certificate_list.go
+++ b/certificates/certificate_list.go
@@ -7,7 +7,6 @@ package certificates
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -15,22 +14,11 @@ import (
 )
 
 // List implements CertificatesService.
-func (c *client) List(ctx context.Context) ([]ListResponseItem, error) {
-	var resp kcclient.ServiceResponse[ListResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/list", nil, &resp); err != nil {
+func (c *client) List(ctx context.Context) (*kcclient.ServiceResponse[ListResponseItem], error) {
+	resp := &kcclient.ServiceResponse[ListResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/list", nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/certificates/interface.go
+++ b/certificates/interface.go
@@ -18,26 +18,26 @@ type CertificatesService interface {
 	// certificate(s) by their UUID(s).
 	//
 	// See: https://docs.kraft.cloud/api/v1/certificates/#getting-the-status-of-a-certificate
-	GetByUUIDs(ctx context.Context, uuids ...string) ([]GetResponseItem, error)
+	GetByUUIDs(ctx context.Context, uuids ...string) (*kcclient.ServiceResponse[GetResponseItem], error)
 
 	// GetByNames returns the current status and the properties of one or more
 	// certificate(s) by their names(s).
 	//
 	// See: https://docs.kraft.cloud/api/v1/certificates/#getting-the-status-of-a-certificate
-	GetByNames(ctx context.Context, names ...string) ([]GetResponseItem, error)
+	GetByNames(ctx context.Context, names ...string) (*kcclient.ServiceResponse[GetResponseItem], error)
 
 	// DeleteByUUIDs deletes one or more certificate(s) by their UUID(s).
 	//
 	// See: https://docs.kraft.cloud/api/v1/certificates/#deleting-a-certificate
-	DeleteByUUIDs(ctx context.Context, uuids ...string) ([]DeleteResponseItem, error)
+	DeleteByUUIDs(ctx context.Context, uuids ...string) (*kcclient.ServiceResponse[DeleteResponseItem], error)
 
 	// DeleteByNames deletes one or more certificate(s) by their UUID(s).
 	//
 	// See: https://docs.kraft.cloud/api/v1/certificates/#deleting-a-certificate
-	DeleteByNames(ctx context.Context, names ...string) ([]DeleteResponseItem, error)
+	DeleteByNames(ctx context.Context, names ...string) (*kcclient.ServiceResponse[DeleteResponseItem], error)
 
 	// List all existing certificates.
 	//
 	// See: https://docs.kraft.cloud/api/v1/certificates/#list-existing-certificates
-	List(ctx context.Context) ([]ListResponseItem, error)
+	List(ctx context.Context) (*kcclient.ServiceResponse[ListResponseItem], error)
 }

--- a/images/image_list.go
+++ b/images/image_list.go
@@ -7,7 +7,6 @@ package images
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -15,22 +14,11 @@ import (
 )
 
 // List implements ImagesService.
-func (c *client) List(ctx context.Context) ([]ListResponseItem, error) {
-	var resp kcclient.ServiceResponse[ListResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/list", nil, &resp); err != nil {
+func (c *client) List(ctx context.Context) (*kcclient.ServiceResponse[ListResponseItem], error) {
+	resp := &kcclient.ServiceResponse[ListResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/list", nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/images/interface.go
+++ b/images/interface.go
@@ -20,7 +20,7 @@ type ImagesService interface {
 	// part of the request.
 	//
 	// See: https://docs.kraft.cloud/api/v1/images/#list-existing-images
-	List(ctx context.Context) ([]ListResponseItem, error)
+	List(ctx context.Context) (*kcclient.ServiceResponse[ListResponseItem], error)
 
 	// Delete an image by its provided name.
 	DeleteByName(ctx context.Context, name string) error

--- a/instances/instance_create.go
+++ b/instances/instance_create.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -17,20 +16,16 @@ import (
 )
 
 // Create implements InstancesService.
-func (c *client) Create(ctx context.Context, req CreateRequest) (*CreateResponseItem, error) {
+func (c *client) Create(ctx context.Context, req CreateRequest) (*kcclient.ServiceResponse[CreateResponseItem], error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling request body: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[CreateResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodPost, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[CreateResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodPost, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/instances/instance_delete_by_names.go
+++ b/instances/instance_delete_by_names.go
@@ -17,7 +17,7 @@ import (
 )
 
 // DeleteByNames implements InstancesService.
-func (c *client) DeleteByNames(ctx context.Context, names ...string) ([]DeleteResponseItem, error) {
+func (c *client) DeleteByNames(ctx context.Context, names ...string) (*kcclient.ServiceResponse[DeleteResponseItem], error) {
 	if len(names) == 0 {
 		return nil, errors.New("requires at least one name")
 	}
@@ -32,21 +32,10 @@ func (c *client) DeleteByNames(ctx context.Context, names ...string) ([]DeleteRe
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[DeleteResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[DeleteResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/instances/instance_delete_by_uuids.go
+++ b/instances/instance_delete_by_uuids.go
@@ -17,7 +17,7 @@ import (
 )
 
 // DeleteByUUIDs implements InstancesService.
-func (c *client) DeleteByUUIDs(ctx context.Context, uuids ...string) ([]DeleteResponseItem, error) {
+func (c *client) DeleteByUUIDs(ctx context.Context, uuids ...string) (*kcclient.ServiceResponse[DeleteResponseItem], error) {
 	if len(uuids) == 0 {
 		return nil, errors.New("requires at least one uuid")
 	}
@@ -32,21 +32,10 @@ func (c *client) DeleteByUUIDs(ctx context.Context, uuids ...string) ([]DeleteRe
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[DeleteResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[DeleteResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/instances/instance_get_by_names.go
+++ b/instances/instance_get_by_names.go
@@ -17,7 +17,7 @@ import (
 )
 
 // GetByNames implements InstancesService.
-func (c *client) GetByNames(ctx context.Context, names ...string) ([]GetResponseItem, error) {
+func (c *client) GetByNames(ctx context.Context, names ...string) (*kcclient.ServiceResponse[GetResponseItem], error) {
 	if len(names) == 0 {
 		return nil, errors.New("requires at least one name")
 	}
@@ -32,21 +32,10 @@ func (c *client) GetByNames(ctx context.Context, names ...string) ([]GetResponse
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[GetResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[GetResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/instances/instance_get_by_uuids.go
+++ b/instances/instance_get_by_uuids.go
@@ -17,7 +17,7 @@ import (
 )
 
 // GetByUUIDs implements InstancesService.
-func (c *client) GetByUUIDs(ctx context.Context, uuids ...string) ([]GetResponseItem, error) {
+func (c *client) GetByUUIDs(ctx context.Context, uuids ...string) (*kcclient.ServiceResponse[GetResponseItem], error) {
 	if len(uuids) == 0 {
 		return nil, errors.New("requires at least one uuid")
 	}
@@ -32,21 +32,10 @@ func (c *client) GetByUUIDs(ctx context.Context, uuids ...string) ([]GetResponse
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[GetResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[GetResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/instances/instance_list.go
+++ b/instances/instance_list.go
@@ -7,7 +7,6 @@ package instances
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -15,22 +14,11 @@ import (
 )
 
 // List implements InstancesService.
-func (c *client) List(ctx context.Context) ([]ListResponseItem, error) {
-	var resp kcclient.ServiceResponse[ListResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/list", nil, &resp); err != nil {
+func (c *client) List(ctx context.Context) (*kcclient.ServiceResponse[ListResponseItem], error) {
+	resp := &kcclient.ServiceResponse[ListResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/list", nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/instances/instance_log_by_name.go
+++ b/instances/instance_log_by_name.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -17,7 +16,7 @@ import (
 )
 
 // LogByName implements InstancesService.
-func (c *client) LogByName(ctx context.Context, name string, offset int, limit int) (*LogResponseItem, error) {
+func (c *client) LogByName(ctx context.Context, name string, offset int, limit int) (*kcclient.ServiceResponse[LogResponseItem], error) {
 	if len(name) == 0 {
 		return nil, fmt.Errorf("name cannot be empty")
 	}
@@ -31,14 +30,10 @@ func (c *client) LogByName(ctx context.Context, name string, offset int, limit i
 		return nil, fmt.Errorf("marshalling request body: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[LogResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/log", bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[LogResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/log", bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/instances/instance_start_by_names.go
+++ b/instances/instance_start_by_names.go
@@ -17,7 +17,7 @@ import (
 )
 
 // StartByNames implements InstancesService.
-func (c *client) StartByNames(ctx context.Context, waitTimeoutMs int, names ...string) ([]StartResponseItem, error) {
+func (c *client) StartByNames(ctx context.Context, waitTimeoutMs int, names ...string) (*kcclient.ServiceResponse[StartResponseItem], error) {
 	if len(names) == 0 {
 		return nil, errors.New("requires at least one name")
 	}
@@ -38,21 +38,10 @@ func (c *client) StartByNames(ctx context.Context, waitTimeoutMs int, names ...s
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[StartResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/start", bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[StartResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/start", bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/instances/instance_start_by_uuids.go
+++ b/instances/instance_start_by_uuids.go
@@ -17,7 +17,7 @@ import (
 )
 
 // StartByUUIDs implements InstancesService.
-func (c *client) StartByUUIDs(ctx context.Context, waitTimeoutMs int, uuids ...string) ([]StartResponseItem, error) {
+func (c *client) StartByUUIDs(ctx context.Context, waitTimeoutMs int, uuids ...string) (*kcclient.ServiceResponse[StartResponseItem], error) {
 	if len(uuids) == 0 {
 		return nil, errors.New("requires at least one uuid")
 	}
@@ -38,21 +38,10 @@ func (c *client) StartByUUIDs(ctx context.Context, waitTimeoutMs int, uuids ...s
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[StartResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/start", bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[StartResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/start", bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/instances/instance_stop_by_names.go
+++ b/instances/instance_stop_by_names.go
@@ -17,7 +17,7 @@ import (
 )
 
 // StopByNames implements InstancesService.
-func (c *client) StopByNames(ctx context.Context, drainTimeoutMs int, force bool, names ...string) ([]StopResponseItem, error) {
+func (c *client) StopByNames(ctx context.Context, drainTimeoutMs int, force bool, names ...string) (*kcclient.ServiceResponse[StopResponseItem], error) {
 	if len(names) == 0 {
 		return nil, errors.New("requires at least one name")
 	}
@@ -39,21 +39,10 @@ func (c *client) StopByNames(ctx context.Context, drainTimeoutMs int, force bool
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[StopResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/stop", bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[StopResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/stop", bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/instances/instance_stop_by_uuids.go
+++ b/instances/instance_stop_by_uuids.go
@@ -17,7 +17,7 @@ import (
 )
 
 // StopByUUIDs implements InstancesService.
-func (c *client) StopByUUIDs(ctx context.Context, drainTimeoutMs int, force bool, uuids ...string) ([]StopResponseItem, error) {
+func (c *client) StopByUUIDs(ctx context.Context, drainTimeoutMs int, force bool, uuids ...string) (*kcclient.ServiceResponse[StopResponseItem], error) {
 	if len(uuids) == 0 {
 		return nil, errors.New("requires at least one uuid")
 	}
@@ -39,21 +39,10 @@ func (c *client) StopByUUIDs(ctx context.Context, drainTimeoutMs int, force bool
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[StopResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/stop", bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[StopResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/stop", bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/instances/instance_wait_by_names.go
+++ b/instances/instance_wait_by_names.go
@@ -17,7 +17,7 @@ import (
 )
 
 // WaitByNames implements InstancesService.
-func (c *client) WaitByNames(ctx context.Context, state State, timeoutMs int, names ...string) ([]WaitResponseItem, error) {
+func (c *client) WaitByNames(ctx context.Context, state State, timeoutMs int, names ...string) (*kcclient.ServiceResponse[WaitResponseItem], error) {
 	if len(names) == 0 {
 		return nil, errors.New("requires at least one name")
 	}
@@ -36,21 +36,10 @@ func (c *client) WaitByNames(ctx context.Context, state State, timeoutMs int, na
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[WaitResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/wait", bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[WaitResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/wait", bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/instances/interface.go
+++ b/instances/interface.go
@@ -20,50 +20,50 @@ type InstancesService interface {
 	// be defined during creation. They cannot be changed later.
 	//
 	// See: https://docs.kraft.cloud/api/v1/instances/#creating-a-new-instance
-	Create(ctx context.Context, req CreateRequest) (*CreateResponseItem, error)
+	Create(ctx context.Context, req CreateRequest) (*kcclient.ServiceResponse[CreateResponseItem], error)
 
 	// GetByUUIDs returns the current state and the configuration of one or
 	// more instance(s) based on the provided UUID(s).
 	//
 	// See: https://docs.kraft.cloud/api/v1/instances/#getting-the-status-of-an-instance
-	GetByUUIDs(ctx context.Context, uuids ...string) ([]GetResponseItem, error)
+	GetByUUIDs(ctx context.Context, uuids ...string) (*kcclient.ServiceResponse[GetResponseItem], error)
 
 	// GetByNames returns the current state and the configuration of one or
 	// more instances based on the provided name(s).
 	//
 	// See: https://docs.kraft.cloud/api/v1/instances/#getting-the-status-of-an-instance
-	GetByNames(ctx context.Context, names ...string) ([]GetResponseItem, error)
+	GetByNames(ctx context.Context, names ...string) (*kcclient.ServiceResponse[GetResponseItem], error)
 
 	// DeleteByUUIDs deletes the specified instances based on their UUID.
 	// After this call the UUIDs of the instances are no longer valid. If the
 	// instances are currently running, they are force stopped.
 	//
 	// See: https://docs.kraft.cloud/api/v1/instances/#deleting-an-instance
-	DeleteByUUIDs(ctx context.Context, uuids ...string) ([]DeleteResponseItem, error)
+	DeleteByUUIDs(ctx context.Context, uuids ...string) (*kcclient.ServiceResponse[DeleteResponseItem], error)
 
 	// DeleteByNames deletes the specified instances based on their names.
 	// After this call the UUIDs of the instances are no longer valid. If the
 	// instances are currently running, they are force stopped.
 	//
 	// See: https://docs.kraft.cloud/api/v1/instances/#deleting-an-instance
-	DeleteByNames(ctx context.Context, names ...string) ([]DeleteResponseItem, error)
+	DeleteByNames(ctx context.Context, names ...string) (*kcclient.ServiceResponse[DeleteResponseItem], error)
 
 	// Lists all existing instances.
 	//
 	// See: https://docs.kraft.cloud/api/v1/instances/#list-existing-instances
-	List(ctx context.Context) ([]ListResponseItem, error)
+	List(ctx context.Context) (*kcclient.ServiceResponse[ListResponseItem], error)
 
 	// Starts a previously stopped instance(s) based on their UUID(s).
 	// Does nothing for instances that are already running.
 	//
 	// See: https://docs.kraft.cloud/api/v1/instances/#starting-an-instance
-	StartByUUIDs(ctx context.Context, waitTimeoutMs int, uuids ...string) ([]StartResponseItem, error)
+	StartByUUIDs(ctx context.Context, waitTimeoutMs int, uuids ...string) (*kcclient.ServiceResponse[StartResponseItem], error)
 
 	// Starts a previously stopped instance(s) based on their name(s).
 	// Does nothing for instances that are already running.
 	//
 	// See: https://docs.kraft.cloud/api/v1/instances/#starting-an-instance
-	StartByNames(ctx context.Context, waitTimeoutMs int, names ...string) ([]StartResponseItem, error)
+	StartByNames(ctx context.Context, waitTimeoutMs int, names ...string) (*kcclient.ServiceResponse[StartResponseItem], error)
 
 	// StopByUUIDs stops the specified instance(s) based on their UUID(s), but
 	// does not destroy them.  All volatile state (e.g., RAM contents) is lost.
@@ -71,7 +71,7 @@ type InstancesService interface {
 	// started again with the start endpoint.
 	//
 	// See: https://docs.kraft.cloud/api/v1/instances/#stopping-an-instance
-	StopByUUIDs(ctx context.Context, drainTimeoutMs int, force bool, uuid ...string) ([]StopResponseItem, error)
+	StopByUUIDs(ctx context.Context, drainTimeoutMs int, force bool, uuid ...string) (*kcclient.ServiceResponse[StopResponseItem], error)
 
 	// StopByNames stops the specified instance(s) based on their name(s), but
 	// does not destroy them.  All volatile state (e.g., RAM contents) is lost.
@@ -79,27 +79,27 @@ type InstancesService interface {
 	// started again with the start endpoint.
 	//
 	// See: https://docs.kraft.cloud/api/v1/instances/#stopping-an-instance
-	StopByNames(ctx context.Context, drainTimeoutMs int, force bool, names ...string) ([]StopResponseItem, error)
+	StopByNames(ctx context.Context, drainTimeoutMs int, force bool, names ...string) (*kcclient.ServiceResponse[StopResponseItem], error)
 
 	// LogByName returns the console output of the specified instance based
 	// on its name.
 	//
 	// See: https://docs.kraft.cloud/api/v1/instances/#retrieve-the-console-output
-	LogByName(ctx context.Context, name string, offset int, limit int) (*LogResponseItem, error)
+	LogByName(ctx context.Context, name string, offset int, limit int) (*kcclient.ServiceResponse[LogResponseItem], error)
 
 	// LogByUUID returns the console output of the specified instance based
 	// on its UUID.
 	//
 	// See: https://docs.kraft.cloud/api/v1/instances/#retrieve-the-console-output
-	LogByUUID(ctx context.Context, uuid string, offset int, limit int) (*LogResponseItem, error)
+	LogByUUID(ctx context.Context, uuid string, offset int, limit int) (*kcclient.ServiceResponse[LogResponseItem], error)
 
 	// WaitByUUIDs waits for the specified instance(s) based on their UUID(s) to
 	// reach the desired state.
 	// See: https://docs.kraft.cloud/api/v1/instances/#waiting-for-an-instance-to-reach-a-desired-state
-	WaitByUUIDs(ctx context.Context, state State, timeoutMs int, uuids ...string) ([]WaitResponseItem, error)
+	WaitByUUIDs(ctx context.Context, state State, timeoutMs int, uuids ...string) (*kcclient.ServiceResponse[WaitResponseItem], error)
 
 	// WaitByNames waits for the specified instance(s) based on their name(s) to
 	// reach the desired state.
 	// See: https://docs.kraft.cloud/api/v1/instances/#waiting-for-an-instance-to-reach-a-desired-state
-	WaitByNames(ctx context.Context, state State, timeoutMs int, names ...string) ([]WaitResponseItem, error)
+	WaitByNames(ctx context.Context, state State, timeoutMs int, names ...string) (*kcclient.ServiceResponse[WaitResponseItem], error)
 }

--- a/services/autoscale/autoscale_create.go
+++ b/services/autoscale/autoscale_create.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -17,20 +16,16 @@ import (
 )
 
 // CreateConfiguration implements AutoscaleService.
-func (c *client) CreateConfiguration(ctx context.Context, req CreateRequest) (*CreateResponseItem, error) {
+func (c *client) CreateConfiguration(ctx context.Context, req CreateRequest) (*kcclient.ServiceResponse[CreateResponseItem], error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling request body: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[CreateResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodPost, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[CreateResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodPost, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/services/autoscale/autoscale_delete_by_name.go
+++ b/services/autoscale/autoscale_delete_by_name.go
@@ -17,7 +17,7 @@ import (
 )
 
 // DeleteConfigurationByName implements AutoscaleService.
-func (c *client) DeleteConfigurationByName(ctx context.Context, name string) (*DeleteResponseItem, error) {
+func (c *client) DeleteConfigurationByName(ctx context.Context, name string) (*kcclient.ServiceResponse[DeleteResponseItem], error) {
 	if name == "" {
 		return nil, errors.New("name cannot be empty")
 	}
@@ -29,14 +29,10 @@ func (c *client) DeleteConfigurationByName(ctx context.Context, name string) (*D
 		return nil, fmt.Errorf("marshalling request body: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[DeleteResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[DeleteResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/services/autoscale/autoscale_delete_by_uuid.go
+++ b/services/autoscale/autoscale_delete_by_uuid.go
@@ -16,21 +16,17 @@ import (
 )
 
 // DeleteConfigurationByUUID implements AutoscaleService.
-func (c *client) DeleteConfigurationByUUID(ctx context.Context, uuid string) (*DeleteResponseItem, error) {
+func (c *client) DeleteConfigurationByUUID(ctx context.Context, uuid string) (*kcclient.ServiceResponse[DeleteResponseItem], error) {
 	if uuid == "" {
 		return nil, errors.New("UUID cannot be empty")
 	}
 
 	endpoint := services.Endpoint + "/" + uuid + AutoscaleEndpoint
 
-	var resp kcclient.ServiceResponse[DeleteResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodDelete, endpoint, nil, &resp); err != nil {
+	resp := &kcclient.ServiceResponse[DeleteResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodDelete, endpoint, nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/services/autoscale/autoscale_get_by_name.go
+++ b/services/autoscale/autoscale_get_by_name.go
@@ -17,7 +17,7 @@ import (
 )
 
 // GetConfigurationByName implements AutoscaleService.
-func (c *client) GetConfigurationByName(ctx context.Context, name string) (*GetResponseItem, error) {
+func (c *client) GetConfigurationByName(ctx context.Context, name string) (*kcclient.ServiceResponse[GetResponseItem], error) {
 	if name == "" {
 		return nil, errors.New("name cannot be empty")
 	}
@@ -27,14 +27,10 @@ func (c *client) GetConfigurationByName(ctx context.Context, name string) (*GetR
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[GetResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[GetResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/services/autoscale/autoscale_get_by_uuid.go
+++ b/services/autoscale/autoscale_get_by_uuid.go
@@ -16,21 +16,17 @@ import (
 )
 
 // GetConfigurationByUUID implements AutoscaleService.
-func (c *client) GetConfigurationByUUID(ctx context.Context, uuid string) (*GetResponseItem, error) {
+func (c *client) GetConfigurationByUUID(ctx context.Context, uuid string) (*kcclient.ServiceResponse[GetResponseItem], error) {
 	if uuid == "" {
 		return nil, errors.New("UUID cannot be empty")
 	}
 
 	endpoint := services.Endpoint + "/" + uuid + AutoscaleEndpoint
 
-	var resp kcclient.ServiceResponse[GetResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, endpoint, nil, &resp); err != nil {
+	resp := &kcclient.ServiceResponse[GetResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, endpoint, nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/services/autoscale/autoscale_policy_add.go
+++ b/services/autoscale/autoscale_policy_add.go
@@ -18,7 +18,7 @@ import (
 )
 
 // AddPolicy implements AutoscaleService.
-func (c *client) AddPolicy(ctx context.Context, uuid string, req Policy) (*AddPolicyResponseItem, error) {
+func (c *client) AddPolicy(ctx context.Context, uuid string, req Policy) (*kcclient.ServiceResponse[AddPolicyResponseItem], error) {
 	if uuid == "" {
 		return nil, errors.New("UUID cannot be empty")
 	}
@@ -28,14 +28,10 @@ func (c *client) AddPolicy(ctx context.Context, uuid string, req Policy) (*AddPo
 		return nil, fmt.Errorf("error marshalling request body: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[AddPolicyResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodPost, services.Endpoint+"/"+uuid+"/autoscale/policies", bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[AddPolicyResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodPost, services.Endpoint+"/"+uuid+"/autoscale/policies", bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/services/autoscale/autoscale_policy_delete_by_name.go
+++ b/services/autoscale/autoscale_policy_delete_by_name.go
@@ -16,21 +16,17 @@ import (
 )
 
 // DeletePolicyByName implements AutoscaleService.
-func (c *client) DeletePolicyByName(ctx context.Context, autoscaleUUID, policyName string) (*DeletePolicyResponseItem, error) {
+func (c *client) DeletePolicyByName(ctx context.Context, autoscaleUUID, policyName string) (*kcclient.ServiceResponse[DeletePolicyResponseItem], error) {
 	if autoscaleUUID == "" || policyName == "" {
 		return nil, errors.New("policyName and autoscaleUUID cannot be empty")
 	}
 
 	endpoint := services.Endpoint + "/" + autoscaleUUID + AutoscaleEndpoint + AutoscalePolicyEndpoint + "/" + policyName
 
-	var resp kcclient.ServiceResponse[DeletePolicyResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodDelete, endpoint, nil, &resp); err != nil {
+	resp := &kcclient.ServiceResponse[DeletePolicyResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodDelete, endpoint, nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/services/autoscale/autoscale_policy_get_by_name.go
+++ b/services/autoscale/autoscale_policy_get_by_name.go
@@ -16,19 +16,15 @@ import (
 )
 
 // GetPolicyByName implements AutoscaleService.
-func (c *client) GetPolicyByName(ctx context.Context, uuid, name string) (*GetPolicyResponseItem, error) {
+func (c *client) GetPolicyByName(ctx context.Context, uuid, name string) (*kcclient.ServiceResponse[GetPolicyResponseItem], error) {
 	if name == "" {
 		return nil, errors.New("name cannot be empty")
 	}
 
-	var resp kcclient.ServiceResponse[GetPolicyResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, services.Endpoint+"/"+uuid+"/autoscale/policies/"+name, nil, &resp); err != nil {
+	resp := &kcclient.ServiceResponse[GetPolicyResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, services.Endpoint+"/"+uuid+"/autoscale/policies/"+name, nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/services/autoscale/interface.go
+++ b/services/autoscale/interface.go
@@ -15,31 +15,31 @@ type AutoscaleService interface {
 	kcclient.ServiceClient[AutoscaleService]
 
 	// CreateConfiguration creates a new autoscale configuration.
-	CreateConfiguration(ctx context.Context, req CreateRequest) (*CreateResponseItem, error)
+	CreateConfiguration(ctx context.Context, req CreateRequest) (*kcclient.ServiceResponse[CreateResponseItem], error)
 
 	// GetConfigurationByName returns the current state and the configuration of
 	// an autoscale configuration
-	GetConfigurationByName(ctx context.Context, name string) (*GetResponseItem, error)
+	GetConfigurationByName(ctx context.Context, name string) (*kcclient.ServiceResponse[GetResponseItem], error)
 
 	// GetConfigurationByUUID returns the current state and the configuration of
 	// an autoscale configuration
-	GetConfigurationByUUID(ctx context.Context, uuid string) (*GetResponseItem, error)
+	GetConfigurationByUUID(ctx context.Context, uuid string) (*kcclient.ServiceResponse[GetResponseItem], error)
 
 	// DeleteConfigurationByUUID deletes an autoscale configuration given its
 	// UUID.
-	DeleteConfigurationByUUID(ctx context.Context, uuid string) (*DeleteResponseItem, error)
+	DeleteConfigurationByUUID(ctx context.Context, uuid string) (*kcclient.ServiceResponse[DeleteResponseItem], error)
 
 	// DeleteConfigurationByName deletes an autoscale configuration given its
 	// name.
-	DeleteConfigurationByName(ctx context.Context, name string) (*DeleteResponseItem, error)
+	DeleteConfigurationByName(ctx context.Context, name string) (*kcclient.ServiceResponse[DeleteResponseItem], error)
 
 	// AddPolicy adds a new autoscale policy to an autoscale configuration.
-	AddPolicy(ctx context.Context, uuid string, req Policy) (*AddPolicyResponseItem, error)
+	AddPolicy(ctx context.Context, uuid string, req Policy) (*kcclient.ServiceResponse[AddPolicyResponseItem], error)
 
 	// GetPolicyByName returns the current state and configuration of an
 	// autoscale policy.
-	GetPolicyByName(ctx context.Context, uuid, name string) (*GetPolicyResponseItem, error)
+	GetPolicyByName(ctx context.Context, uuid, name string) (*kcclient.ServiceResponse[GetPolicyResponseItem], error)
 
 	// DeletePolicyByName deletes an autoscale policy given its name.
-	DeletePolicyByName(ctx context.Context, uuid, name string) (*DeletePolicyResponseItem, error)
+	DeletePolicyByName(ctx context.Context, uuid, name string) (*kcclient.ServiceResponse[DeletePolicyResponseItem], error)
 }

--- a/services/interface.go
+++ b/services/interface.go
@@ -26,17 +26,17 @@ type ServicesService interface {
 	// groups with different properties with the same call.
 	//
 	// See: https://docs.kraft.cloud/api/v1/services/#creating-new-service-groups
-	Create(ctx context.Context, req CreateRequest) (*CreateResponseItem, error)
+	Create(ctx context.Context, req CreateRequest) (*kcclient.ServiceResponse[CreateResponseItem], error)
 
 	// GetByUUID returns the current state and the configuration of a service group.
 	//
 	// See: https://docs.kraft.cloud/api/v1/services/#getting-the-state-of-a-service-group
-	GetByUUID(ctx context.Context, uuid string) (*GetResponseItem, error)
+	GetByUUID(ctx context.Context, uuid string) (*kcclient.ServiceResponse[GetResponseItem], error)
 
 	// GetByName returns the current state and the configuration of a service group.
 	//
 	// See: https://docs.kraft.cloud/api/v1/services/#getting-the-state-of-a-service-group
-	GetByName(ctx context.Context, name string) (*GetResponseItem, error)
+	GetByName(ctx context.Context, name string) (*kcclient.ServiceResponse[GetResponseItem], error)
 
 	// DeleteByUUID the specified service group based on its UUID.  Fails if there
 	// are still instances attached to group. After this call the UUID of the
@@ -45,7 +45,7 @@ type ServicesService interface {
 	// This operation cannot be undone.
 	//
 	// See: https://docs.kraft.cloud/api/v1/services/#deleting-a-service-group
-	DeleteByUUID(ctx context.Context, uuid string) (*DeleteResponseItem, error)
+	DeleteByUUID(ctx context.Context, uuid string) (*kcclient.ServiceResponse[DeleteResponseItem], error)
 
 	// DeleteByName the specified service group based on its name.  Fails if there
 	// are still instances attached to group. After this call the UUID of the
@@ -54,7 +54,7 @@ type ServicesService interface {
 	// This operation cannot be undone.
 	//
 	// See: https://docs.kraft.cloud/api/v1/services/#deleting-a-service-group
-	DeleteByName(ctx context.Context, name string) (*DeleteResponseItem, error)
+	DeleteByName(ctx context.Context, name string) (*kcclient.ServiceResponse[DeleteResponseItem], error)
 
 	// Lists all existing service groups. You can filter by persistence and DNS
 	// name. The latter can be used to lookup the UUID of the service group that
@@ -66,5 +66,5 @@ type ServicesService interface {
 	// endpoints, for example, to delete (empty) groups.
 	//
 	// See: https://docs.kraft.cloud/api/v1/services/#list-existing-service-groups
-	List(ctx context.Context) ([]ListResponseItem, error)
+	List(ctx context.Context) (*kcclient.ServiceResponse[ListResponseItem], error)
 }

--- a/services/service_create.go
+++ b/services/service_create.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -17,20 +16,16 @@ import (
 )
 
 // Creates implements ServicesService.
-func (c *client) Create(ctx context.Context, req CreateRequest) (*CreateResponseItem, error) {
+func (c *client) Create(ctx context.Context, req CreateRequest) (*kcclient.ServiceResponse[CreateResponseItem], error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling request body: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[CreateResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodPost, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[CreateResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodPost, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/services/service_delete_by_name.go
+++ b/services/service_delete_by_name.go
@@ -17,7 +17,7 @@ import (
 )
 
 // DeleteByName implements ServicesService.
-func (c *client) DeleteByName(ctx context.Context, name string) (*DeleteResponseItem, error) {
+func (c *client) DeleteByName(ctx context.Context, name string) (*kcclient.ServiceResponse[DeleteResponseItem], error) {
 	if name == "" {
 		return nil, errors.New("name cannot be empty")
 	}
@@ -29,14 +29,10 @@ func (c *client) DeleteByName(ctx context.Context, name string) (*DeleteResponse
 		return nil, fmt.Errorf("marshalling request body: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[DeleteResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[DeleteResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/services/service_delete_by_uuid.go
+++ b/services/service_delete_by_uuid.go
@@ -15,19 +15,15 @@ import (
 )
 
 // DeleteByUUID implements ServicesService.
-func (c *client) DeleteByUUID(ctx context.Context, uuid string) (*DeleteResponseItem, error) {
+func (c *client) DeleteByUUID(ctx context.Context, uuid string) (*kcclient.ServiceResponse[DeleteResponseItem], error) {
 	if uuid == "" {
 		return nil, errors.New("UUID cannot be empty")
 	}
 
-	var resp kcclient.ServiceResponse[DeleteResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint+"/"+uuid, nil, &resp); err != nil {
+	resp := &kcclient.ServiceResponse[DeleteResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint+"/"+uuid, nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/services/service_get_by_name.go
+++ b/services/service_get_by_name.go
@@ -17,7 +17,7 @@ import (
 )
 
 // GetByName implements ServicesService.
-func (c *client) GetByName(ctx context.Context, name string) (*GetResponseItem, error) {
+func (c *client) GetByName(ctx context.Context, name string) (*kcclient.ServiceResponse[GetResponseItem], error) {
 	if name == "" {
 		return nil, errors.New("name cannot be empty")
 	}
@@ -27,14 +27,10 @@ func (c *client) GetByName(ctx context.Context, name string) (*GetResponseItem, 
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[GetResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[GetResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/services/service_get_by_uuid.go
+++ b/services/service_get_by_uuid.go
@@ -15,21 +15,17 @@ import (
 )
 
 // GetByUUID implements ServicesService.
-func (c *client) GetByUUID(ctx context.Context, uuid string) (*GetResponseItem, error) {
+func (c *client) GetByUUID(ctx context.Context, uuid string) (*kcclient.ServiceResponse[GetResponseItem], error) {
 	if uuid == "" {
 		return nil, errors.New("UUID cannot be empty")
 	}
 
 	endpoint := Endpoint + "/" + uuid
 
-	var resp kcclient.ServiceResponse[GetResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, endpoint, nil, &resp); err != nil {
+	resp := &kcclient.ServiceResponse[GetResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, endpoint, nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/services/service_list.go
+++ b/services/service_list.go
@@ -7,7 +7,6 @@ package services
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -15,22 +14,11 @@ import (
 )
 
 // List implements ServicesService.
-func (c *client) List(ctx context.Context) ([]ListResponseItem, error) {
-	var resp kcclient.ServiceResponse[ListResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/list", nil, &resp); err != nil {
+func (c *client) List(ctx context.Context) (*kcclient.ServiceResponse[ListResponseItem], error) {
+	resp := &kcclient.ServiceResponse[ListResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/list", nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }

--- a/users/interface.go
+++ b/users/interface.go
@@ -17,5 +17,5 @@ type UsersService interface {
 	// Lists quota usage and limits of your user account. Limits are hard limits
 	// that cannot be exceeded.
 	// https://docs.kraft.cloud/api/v1/users/#list-quota-usage-and-limits
-	Quotas(ctx context.Context) (*QuotasResponseItem, error)
+	Quotas(ctx context.Context) (*kcclient.ServiceResponse[QuotasResponseItem], error)
 }

--- a/users/users_quota.go
+++ b/users/users_quota.go
@@ -7,7 +7,6 @@ package users
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -15,15 +14,11 @@ import (
 )
 
 // Quotas implements UsersService.
-func (c *client) Quotas(ctx context.Context) (*QuotasResponseItem, error) {
-	var resp kcclient.ServiceResponse[QuotasResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/quotas", nil, &resp); err != nil {
+func (c *client) Quotas(ctx context.Context) (*kcclient.ServiceResponse[QuotasResponseItem], error) {
+	resp := &kcclient.ServiceResponse[QuotasResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/quotas", nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/volumes/interface.go
+++ b/volumes/interface.go
@@ -21,17 +21,17 @@ type VolumesService interface {
 	// be changed after creation.
 	//
 	// See: https://docs.kraft.cloud/api/v1/volumes/#creating-volumes
-	Create(ctx context.Context, name string, sizeMB int) (*CreateResponseItem, error)
+	Create(ctx context.Context, name string, sizeMB int) (*kcclient.ServiceResponse[CreateResponseItem], error)
 
 	// GetByUUID returns the current state and the configuration of a volume.
 	//
 	// See: https://docs.kraft.cloud/api/v1/volumes/#getting-the-status-of-a-volume
-	GetByUUID(ctx context.Context, uuid string) (*GetResponseItem, error)
+	GetByUUID(ctx context.Context, uuid string) (*kcclient.ServiceResponse[GetResponseItem], error)
 
 	// GetByName returns the current state and the configuration of a volume.
 	//
 	// See: https://docs.kraft.cloud/api/v1/volumes/#getting-the-status-of-a-volume
-	GetByName(ctx context.Context, name string) (*GetResponseItem, error)
+	GetByName(ctx context.Context, name string) (*kcclient.ServiceResponse[GetResponseItem], error)
 
 	// AttachByUUID a volume to an instance so that the volume is mounted when the
 	// instance starts using the volume and instance name.  The volume needs to be
@@ -39,7 +39,7 @@ type VolumesService interface {
 	// instance can have only one volume attached at most.
 	//
 	// See: https://docs.kraft.cloud/api/v1/volumes/#attaching-a-volume-to-an-instance
-	AttachByUUID(ctx context.Context, volUUID, instanceUUID, at string, readOnly bool) (*AttachResponseItem, error)
+	AttachByUUID(ctx context.Context, volUUID, instanceUUID, at string, readOnly bool) (*kcclient.ServiceResponse[AttachResponseItem], error)
 
 	// AttachByName a volume to an instance so that the volume is mounted when the
 	// instance starts using the volume and instance name.  The volume needs to be
@@ -47,7 +47,7 @@ type VolumesService interface {
 	// instance can have only one volume attached at most.
 	//
 	// See: https://docs.kraft.cloud/api/v1/volumes/#attaching-a-volume-to-an-instance
-	AttachByName(ctx context.Context, volName, instanceName, at string, readOnly bool) (*AttachResponseItem, error)
+	AttachByName(ctx context.Context, volName, instanceName, at string, readOnly bool) (*kcclient.ServiceResponse[AttachResponseItem], error)
 
 	// DetachByUUID a volume from an instance based on the volume's UUID.  The
 	// instance from which to detach must in stopped state. If the volume has been
@@ -55,7 +55,7 @@ type VolumesService interface {
 	// persistent (i.e., it survives the deletion of the instance).
 	//
 	// See: https://docs.kraft.cloud/api/v1/volumes/#detaching-a-volume-from-an-instance
-	DetachByUUID(ctx context.Context, uuid string) (*DetachResponseItem, error)
+	DetachByUUID(ctx context.Context, uuid string) (*kcclient.ServiceResponse[DetachResponseItem], error)
 
 	// DetachByNam a volume from an instance based on the volume's name.  The
 	// instance from which to detach must in stopped state. If the volume has been
@@ -63,26 +63,26 @@ type VolumesService interface {
 	// persistent (i.e., it survives the deletion of the instance).
 	//
 	// See: https://docs.kraft.cloud/api/v1/volumes/#detaching-a-volume-from-an-instance
-	DetachByName(ctx context.Context, name string) (*DetachResponseItem, error)
+	DetachByName(ctx context.Context, name string) (*kcclient.ServiceResponse[DetachResponseItem], error)
 
 	// DeletebyUUID the specified volume based on its UUID.  Fails if the volume is
 	// still attached to an instance. After this call the UUID of the volumes is
 	// no longer valid.
 	//
 	// See: https://docs.kraft.cloud/api/v1/volumes/#deleting-a-volume
-	DeleteByUUID(ctx context.Context, uuid string) (*DeleteResponseItem, error)
+	DeleteByUUID(ctx context.Context, uuid string) (*kcclient.ServiceResponse[DeleteResponseItem], error)
 
 	// DeleteByName the specified volume based on its name.  Fails if the volume
 	// is still attached to an instance. After this call the UUID of the volumes
 	// is no longer valid.
 	//
 	// See: https://docs.kraft.cloud/api/v1/volumes/#deleting-a-volume
-	DeleteByName(ctx context.Context, name string) (*DeleteResponseItem, error)
+	DeleteByName(ctx context.Context, name string) (*kcclient.ServiceResponse[DeleteResponseItem], error)
 
 	// Lists all existing volumes. You can filter by persistence and volume
 	// state. The returned volumes fulfill all provided filter criteria. No
 	// particular value is assumed if a filter is not part of the request.
 	//
 	// See: https://docs.kraft.cloud/api/v1/volumes/#list-existing-volumes
-	List(ctx context.Context) ([]ListResponseItem, error)
+	List(ctx context.Context) (*kcclient.ServiceResponse[ListResponseItem], error)
 }

--- a/volumes/volume_attach_by_name.go
+++ b/volumes/volume_attach_by_name.go
@@ -17,7 +17,7 @@ import (
 )
 
 // AttachByName implements VolumesService.
-func (c *client) AttachByName(ctx context.Context, volName, instanceName, at string, readOnly bool) (*AttachResponseItem, error) {
+func (c *client) AttachByName(ctx context.Context, volName, instanceName, at string, readOnly bool) (*kcclient.ServiceResponse[AttachResponseItem], error) {
 	if volName == "" {
 		return nil, errors.New("volume name cannot be empty")
 	}
@@ -40,14 +40,10 @@ func (c *client) AttachByName(ctx context.Context, volName, instanceName, at str
 		return nil, fmt.Errorf("error marshalling request body: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[AttachResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/attach", bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[AttachResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/attach", bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/volumes/volume_attach_by_uuid.go
+++ b/volumes/volume_attach_by_uuid.go
@@ -17,7 +17,7 @@ import (
 )
 
 // AttachByUUID implements VolumesService.
-func (c *client) AttachByUUID(ctx context.Context, volUUID, instanceUUID, at string, readOnly bool) (*AttachResponseItem, error) {
+func (c *client) AttachByUUID(ctx context.Context, volUUID, instanceUUID, at string, readOnly bool) (*kcclient.ServiceResponse[AttachResponseItem], error) {
 	if volUUID == "" {
 		return nil, errors.New("volume name cannot be empty")
 	}
@@ -40,14 +40,10 @@ func (c *client) AttachByUUID(ctx context.Context, volUUID, instanceUUID, at str
 		return nil, fmt.Errorf("error marshalling request body: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[AttachResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/attach", bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[AttachResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/attach", bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/volumes/volume_delete_by_name.go
+++ b/volumes/volume_delete_by_name.go
@@ -17,7 +17,7 @@ import (
 )
 
 // DeleteByName implements VolumesService.
-func (c *client) DeleteByName(ctx context.Context, name string) (*DeleteResponseItem, error) {
+func (c *client) DeleteByName(ctx context.Context, name string) (*kcclient.ServiceResponse[DeleteResponseItem], error) {
 	if name == "" {
 		return nil, errors.New("name cannot be empty")
 	}
@@ -27,14 +27,10 @@ func (c *client) DeleteByName(ctx context.Context, name string) (*DeleteResponse
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[DeleteResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[DeleteResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/volumes/volume_delete_by_uuid.go
+++ b/volumes/volume_delete_by_uuid.go
@@ -15,19 +15,15 @@ import (
 )
 
 // DeleteByUUID implements VolumesService.
-func (c *client) DeleteByUUID(ctx context.Context, uuidOrName string) (*DeleteResponseItem, error) {
+func (c *client) DeleteByUUID(ctx context.Context, uuidOrName string) (*kcclient.ServiceResponse[DeleteResponseItem], error) {
 	if uuidOrName == "" {
 		return nil, errors.New("UUID cannot be empty")
 	}
 
-	var resp kcclient.ServiceResponse[DeleteResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint+"/"+uuidOrName, nil, &resp); err != nil {
+	resp := &kcclient.ServiceResponse[DeleteResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodDelete, Endpoint+"/"+uuidOrName, nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/volumes/volume_detach_by_name.go
+++ b/volumes/volume_detach_by_name.go
@@ -17,7 +17,7 @@ import (
 )
 
 // DetachByName implements VolumesService.
-func (c *client) DetachByName(ctx context.Context, name string) (*DetachResponseItem, error) {
+func (c *client) DetachByName(ctx context.Context, name string) (*kcclient.ServiceResponse[DetachResponseItem], error) {
 	if name == "" {
 		return nil, errors.New("name cannot be empty")
 	}
@@ -27,14 +27,10 @@ func (c *client) DetachByName(ctx context.Context, name string) (*DetachResponse
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[DetachResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/detach", bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[DetachResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/detach", bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/volumes/volume_detach_by_uuid.go
+++ b/volumes/volume_detach_by_uuid.go
@@ -15,19 +15,15 @@ import (
 )
 
 // DetachByUUID implements VolumesService.
-func (c *client) DetachByUUID(ctx context.Context, uuid string) (*DetachResponseItem, error) {
+func (c *client) DetachByUUID(ctx context.Context, uuid string) (*kcclient.ServiceResponse[DetachResponseItem], error) {
 	if uuid == "" {
 		return nil, errors.New("UUID cannot be empty")
 	}
 
-	var resp kcclient.ServiceResponse[DetachResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/"+uuid+"/detach", nil, &resp); err != nil {
+	resp := &kcclient.ServiceResponse[DetachResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodPut, Endpoint+"/"+uuid+"/detach", nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/volumes/volume_get_by_name.go
+++ b/volumes/volume_get_by_name.go
@@ -17,7 +17,7 @@ import (
 )
 
 // GetByName implements VolumesService.
-func (c *client) GetByName(ctx context.Context, name string) (*GetResponseItem, error) {
+func (c *client) GetByName(ctx context.Context, name string) (*kcclient.ServiceResponse[GetResponseItem], error) {
 	if name == "" {
 		return nil, errors.New("name cannot be empty")
 	}
@@ -27,14 +27,10 @@ func (c *client) GetByName(ctx context.Context, name string) (*GetResponseItem, 
 		return nil, fmt.Errorf("encoding JSON object: %w", err)
 	}
 
-	var resp kcclient.ServiceResponse[GetResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), &resp); err != nil {
+	resp := &kcclient.ServiceResponse[GetResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/volumes/volume_get_by_uuid.go
+++ b/volumes/volume_get_by_uuid.go
@@ -15,19 +15,15 @@ import (
 )
 
 // GetByUUID implements VolumesService.
-func (c *client) GetByUUID(ctx context.Context, uuid string) (*GetResponseItem, error) {
+func (c *client) GetByUUID(ctx context.Context, uuid string) (*kcclient.ServiceResponse[GetResponseItem], error) {
 	if uuid == "" {
 		return nil, errors.New("UUID cannot be empty")
 	}
 
-	var resp kcclient.ServiceResponse[GetResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/"+uuid, nil, &resp); err != nil {
+	resp := &kcclient.ServiceResponse[GetResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/"+uuid, nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	item, err := resp.FirstOrErr()
-	if err != nil {
-		return nil, errors.Join(err, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-	}
-	return item, nil
+	return resp, nil
 }

--- a/volumes/volume_list.go
+++ b/volumes/volume_list.go
@@ -7,7 +7,6 @@ package volumes
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -15,22 +14,11 @@ import (
 )
 
 // List implements VolumesService.
-func (c *client) List(ctx context.Context) ([]ListResponseItem, error) {
-	var resp kcclient.ServiceResponse[ListResponseItem]
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/list", nil, &resp); err != nil {
+func (c *client) List(ctx context.Context) (*kcclient.ServiceResponse[ListResponseItem], error) {
+	resp := &kcclient.ServiceResponse[ListResponseItem]{}
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/list", nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 
-	items, err := resp.AllOrErr()
-	if err != nil {
-		errs := make([]error, 0, len(items)+1)
-		errs = append(errs, err)
-		for _, item := range items {
-			if item.Error != nil {
-				errs = append(errs, fmt.Errorf("%s (code=%d)", item.Message, *item.Error))
-			}
-		}
-		return nil, errors.Join(errs...)
-	}
-	return items, nil
+	return resp, nil
 }


### PR DESCRIPTION
API service methods now return types which hold the **raw API response body**, alongside the usual deserialized data.

This is achieved by embedding a private `bytes.Buffer` into `ServiceResponse[T]` structs, and "piping" `resp.Body` into that buffer before decoding the JSON response.

This is a **breaking change**. Callers will now need to call either of the following methods on the response to retrieve data:
- `resp.AllOrErr()`: returns `[]T`, where `T` is a response item (same as before this PR)
- `resp.RawBody`: returns the raw bytes read from the API response body