### PR TITLE
feat(instances): Introduces `TailLogs`

### DIFF
--- a/instances/instance.go
+++ b/instances/instance.go
@@ -36,3 +36,9 @@ const (
 	// StateStandby indicates that the instance is in standby.
 	StateStandby State = "standby"
 )
+
+// LogDefaultPageSize is the default page size for log requests.
+const LogDefaultPageSize = 4096
+
+// LogMaxPageSize is the maximum page size for log requests.
+const LogMaxPageSize = LogDefaultPageSize*4 - 1

--- a/instances/interface.go
+++ b/instances/interface.go
@@ -7,6 +7,7 @@ package instances
 
 import (
 	"context"
+	"time"
 
 	kcclient "sdk.kraft.cloud/client"
 )
@@ -57,6 +58,10 @@ type InstancesService interface {
 	//
 	// See: https://docs.kraft.cloud/api/v1/instances/#retrieve-the-console-output
 	Log(ctx context.Context, id string, offset int, limit int) (*kcclient.ServiceResponse[LogResponseItem], error)
+
+	// TailLogs is a utility method which returns a channel that streams the
+	// console output of the specified instance.
+	TailLogs(ctx context.Context, id string, follow bool, tail int, delay time.Duration) (chan string, chan error, error)
 
 	// Wait waits for the specified instance(s) to reach the desired state.
 	//


### PR DESCRIPTION
This commit introduces a utility method for the tailing of kraftcloud vm instances logs, which:

1. Uses a go routine and a channel for sending and receiving log lines which allows for asynchronous and uninterrupted reading and displaying of logs;
2. Uses larger to smaller page size in order to retrieve logs, overall reducing the number of initial calls to gather previous logs whilst increasing the granularity of subsequent calls in order to display more lines in real-time.

Signed-off-by: Alexander Jung <alex@kraft.cloud>
