### PR TITLE
feat(instances): Introduce new `delete-on-stop` flag

### DIFF
--- a/instances/instance.go
+++ b/instances/instance.go
@@ -13,8 +13,13 @@ const Endpoint = "/instances"
 // Feature is a special feature of an instance.
 type Feature string
 
-// FeatureScaleToZero indicates that the instance can be scaled to zero.
-const FeatureScaleToZero Feature = "scale-to-zero"
+const (
+	// FeatureScaleToZero indicates that the instance can be scaled to zero.
+	FeatureScaleToZero Feature = "scale-to-zero"
+
+	// FeatureDeleteOnStop indicates that the instance should be deleted when stopped.
+	FeatureDeleteOnStop Feature = "delete-on-stop"
+)
 
 // State is the state of an instance.
 type State string

--- a/metros/metro_list.go
+++ b/metros/metro_list.go
@@ -47,7 +47,7 @@ func testMetroAlive(metro, ip string) time.Duration {
 
 // fillMetroIP looks up the IP address of the metro using the DNS name.
 func fillMetroIP(metro string) string {
-	url := "api." + metro + ".kraft.cloud"
+	url := metro + ".kraft.host"
 
 	ips, err := net.LookupIP(url)
 	if err != nil {


### PR DESCRIPTION

Also display the host IP instead of the API, but still use the API one to detect if server is online.