### PR TITLE
feat: Introduce `WithTimeout` and `WithRetries`

### DIFF
--- a/certificates/client.go
+++ b/certificates/client.go
@@ -53,6 +53,15 @@ func (c *client) WithTimeout(to time.Duration) CertificatesService {
 	return ccpy
 }
 
+// WithRetries returns a ServiceRequest that uses the specified number of
+// retries to make after a timed out request.  Note that this is specifically
+// only for timed-out requests and API requests which fail are not retried.
+func (c *client) WithRetries(retries int) CertificatesService {
+	ccpy := c.clone()
+	ccpy.request = c.request.WithRetries(retries)
+	return ccpy
+}
+
 // clone returns a shallow copy of c.
 func (c *client) clone() *client {
 	ccpy := *c

--- a/client/options/options.go
+++ b/client/options/options.go
@@ -7,14 +7,20 @@
 // options.
 package options
 
-import "sdk.kraft.cloud/client/httpclient"
+import (
+	"time"
+
+	"sdk.kraft.cloud/client/httpclient"
+)
 
 // Options contain necessary information for connecting to a KraftCloud service
 // endpoint.
 type Options struct {
-	token        string
-	defaultMetro string
-	httpClient   httpclient.HTTPClient
+	token          string
+	defaultTimeout time.Duration
+	defaultRetries int
+	defaultMetro   string
+	httpClient     httpclient.HTTPClient
 }
 
 func (opts *Options) SetToken(token string) {
@@ -23,6 +29,22 @@ func (opts *Options) SetToken(token string) {
 
 func (opts *Options) Token() string {
 	return opts.token
+}
+
+func (opts *Options) SetDefaultTimeout(timeout time.Duration) {
+	opts.defaultTimeout = timeout
+}
+
+func (opts *Options) DefaultTimeout() time.Duration {
+	return opts.defaultTimeout
+}
+
+func (opts *Options) SetDefaultRetries(retries int) {
+	opts.defaultRetries = retries
+}
+
+func (opts *Options) DefaultRetries() int {
+	return opts.defaultRetries
 }
 
 func (opts *Options) SetDefaultMetro(metro string) {

--- a/client/service_client.go
+++ b/client/service_client.go
@@ -23,6 +23,11 @@ type ServiceClient[T any] interface {
 	// WithTimeout sets the timeout when making the request.
 	WithTimeout(time.Duration) T
 
+	// WithRetries sets the number of retries to make after a timed out request.
+	// Note that this is specifically only for timed-out requests and API requests
+	// which fail are not retried.
+	WithRetries(int) T
+
 	// WithHTTPClient overwrites the base HTTP client.
 	WithHTTPClient(httpclient.HTTPClient) T
 }

--- a/client/service_request.go
+++ b/client/service_request.go
@@ -30,7 +30,8 @@ type ServiceRequest struct {
 
 	metro      string
 	httpClient httpclient.HTTPClient
-	timeout    time.Duration
+	timeout    *time.Duration
+	retries    *int
 }
 
 // NewServiceRequestFromDefaultOptions is a constructor method which uses the
@@ -53,7 +54,16 @@ func (r *ServiceRequest) WithMetro(m string) *ServiceRequest {
 // duration in API requests.
 func (r *ServiceRequest) WithTimeout(to time.Duration) *ServiceRequest {
 	rcpy := r.clone()
-	rcpy.timeout = to
+	rcpy.timeout = &to
+	return rcpy
+}
+
+// WithRetries returns a ServiceRequest that uses the specified number of
+// retries to make after a timed out request.  Note that this is specifically
+// only for timed-out requests and API requests which fail are not retried.
+func (r *ServiceRequest) WithRetries(retries int) *ServiceRequest {
+	rcpy := r.clone()
+	rcpy.retries = &retries
 	return rcpy
 }
 
@@ -128,6 +138,39 @@ func (r *ServiceRequest) DoWithAuth(req *http.Request) (*http.Response, error) {
 	hc := r.opts.HTTPClient()
 	if r.httpClient != nil {
 		hc = r.httpClient
+	}
+
+	to := r.opts.DefaultTimeout()
+	if r.timeout != nil {
+		to = *r.timeout
+	}
+
+	retries := r.opts.DefaultRetries()
+	if r.retries != nil {
+		retries = *r.retries
+	}
+
+	if retries > 0 {
+		var resp *http.Response
+		var err error
+
+		for i := 0; i < retries; i++ {
+			ctx, _ := context.WithTimeout(req.Context(), to) //nolint:all
+			resp, err = hc.Do(req.WithContext(ctx))
+			if err != nil && slices.ContainsFunc([]string{
+				"i/o timeout",
+				"operation timed out",
+				"context deadline exceeded",
+			}, func(str string) bool {
+				return strings.Contains(err.Error(), str)
+			}) {
+				continue // retry
+			}
+
+			break
+		}
+
+		return resp, err
 	}
 
 	return hc.Do(req)

--- a/images/client.go
+++ b/images/client.go
@@ -53,6 +53,15 @@ func (c *client) WithTimeout(to time.Duration) ImagesService {
 	return ccpy
 }
 
+// WithRetries returns a ServiceRequest that uses the specified number of
+// retries to make after a timed out request.  Note that this is specifically
+// only for timed-out requests and API requests which fail are not retried.
+func (c *client) WithRetries(retries int) ImagesService {
+	ccpy := c.clone()
+	ccpy.request = c.request.WithRetries(retries)
+	return ccpy
+}
+
 // clone returns a shallow copy of c.
 func (c *client) clone() *client {
 	ccpy := *c

--- a/instances/client.go
+++ b/instances/client.go
@@ -53,6 +53,15 @@ func (c *client) WithTimeout(to time.Duration) InstancesService {
 	return ccpy
 }
 
+// WithRetries returns a ServiceRequest that uses the specified number of
+// retries to make after a timed out request.  Note that this is specifically
+// only for timed-out requests and API requests which fail are not retried.
+func (c *client) WithRetries(retries int) InstancesService {
+	ccpy := c.clone()
+	ccpy.request = c.request.WithRetries(retries)
+	return ccpy
+}
+
 // clone returns a shallow copy of c.
 func (c *client) clone() *client {
 	ccpy := *c

--- a/metros/client.go
+++ b/metros/client.go
@@ -53,6 +53,15 @@ func (c *client) WithTimeout(to time.Duration) MetrosService {
 	return ccpy
 }
 
+// WithRetries returns a ServiceRequest that uses the specified number of
+// retries to make after a timed out request.  Note that this is specifically
+// only for timed-out requests and API requests which fail are not retried.
+func (c *client) WithRetries(retries int) MetrosService {
+	ccpy := c.clone()
+	ccpy.request = c.request.WithRetries(retries)
+	return ccpy
+}
+
 // clone returns a shallow copy of c.
 func (c *client) clone() *client {
 	ccpy := *c

--- a/options.go
+++ b/options.go
@@ -7,6 +7,7 @@ package kraftcloud
 
 import (
 	"os"
+	"time"
 
 	"sdk.kraft.cloud/client"
 	"sdk.kraft.cloud/client/httpclient"
@@ -43,6 +44,14 @@ func NewDefaultOptions(opts ...Option) *options.Options {
 
 	if options.DefaultMetro() == "" {
 		options.SetDefaultMetro(client.DefaultMetro)
+	}
+
+	if options.DefaultTimeout() == 0 {
+		options.SetDefaultTimeout(30 * time.Second)
+	}
+
+	if options.DefaultRetries() == 0 {
+		options.SetDefaultRetries(5)
 	}
 
 	if options.HTTPClient() == nil {

--- a/services/autoscale/client.go
+++ b/services/autoscale/client.go
@@ -53,6 +53,15 @@ func (c *client) WithTimeout(to time.Duration) AutoscaleService {
 	return ccpy
 }
 
+// WithRetries returns a ServiceRequest that uses the specified number of
+// retries to make after a timed out request.  Note that this is specifically
+// only for timed-out requests and API requests which fail are not retried.
+func (c *client) WithRetries(retries int) AutoscaleService {
+	ccpy := c.clone()
+	ccpy.request = c.request.WithRetries(retries)
+	return ccpy
+}
+
 // clone returns a shallow copy of c.
 func (c *client) clone() *client {
 	ccpy := *c

--- a/services/client.go
+++ b/services/client.go
@@ -53,6 +53,15 @@ func (c *client) WithTimeout(to time.Duration) ServicesService {
 	return ccpy
 }
 
+// WithRetries returns a ServiceRequest that uses the specified number of
+// retries to make after a timed out request.  Note that this is specifically
+// only for timed-out requests and API requests which fail are not retried.
+func (c *client) WithRetries(retries int) ServicesService {
+	ccpy := c.clone()
+	ccpy.request = c.request.WithRetries(retries)
+	return ccpy
+}
+
 // clone returns a shallow copy of c.
 func (c *client) clone() *client {
 	ccpy := *c

--- a/users/client.go
+++ b/users/client.go
@@ -53,6 +53,15 @@ func (c *client) WithTimeout(to time.Duration) UsersService {
 	return ccpy
 }
 
+// WithRetries returns a ServiceRequest that uses the specified number of
+// retries to make after a timed out request.  Note that this is specifically
+// only for timed-out requests and API requests which fail are not retried.
+func (c *client) WithRetries(retries int) UsersService {
+	ccpy := c.clone()
+	ccpy.request = c.request.WithRetries(retries)
+	return ccpy
+}
+
 // clone returns a shallow copy of c.
 func (c *client) clone() *client {
 	ccpy := *c

--- a/volumes/client.go
+++ b/volumes/client.go
@@ -53,6 +53,15 @@ func (c *client) WithTimeout(to time.Duration) VolumesService {
 	return ccpy
 }
 
+// WithRetries returns a ServiceRequest that uses the specified number of
+// retries to make after a timed out request.  Note that this is specifically
+// only for timed-out requests and API requests which fail are not retried.
+func (c *client) WithRetries(retries int) VolumesService {
+	ccpy := c.clone()
+	ccpy.request = c.request.WithRetries(retries)
+	return ccpy
+}
+
 // clone returns a shallow copy of c.
 func (c *client) clone() *client {
 	ccpy := *c


### PR DESCRIPTION
These have default values of 10 seconds and 3 retries and increases the robustness of API calls on connections which timeout by allowing for a retry _only when a timeout occurs_ and not when an error from the API occurs.

Since this Go module is used by KraftKit, which can have long and complex builds performing many requests via the SDK, this change increases the likelihood of those invocations to succeed, especially on flakey internet connections.