### PR TITLE
feat(instances): Check instance state when tailing

### DIFF
--- a/instances/instance_log.go
+++ b/instances/instance_log.go
@@ -237,7 +237,9 @@ func (c *client) TailLogs(ctx context.Context, id string, follow bool, tail int,
 
 			// We've received the last payload of logs if the size of the logs is less
 			// than the page size, signalling end of file.
-			if startOffset == item.Range.End {
+			if startOffset == item.Range.End ||
+				State(item.State) == StateStopped ||
+				State(item.State) == StateStandby {
 				// First send an EOF to the error channel to signal the end of the logs.
 				errChan <- io.EOF
 

--- a/instances/models.go
+++ b/instances/models.go
@@ -505,6 +505,7 @@ type LogResponseItem struct {
 	Name      string               `json:"name"`
 	Output    string               `json:"output"`
 	Range     LogResponseRange     `json:"range"`
+	State     string               `json:"state"`
 	Available LogResponseAvailable `json:"available"`
 
 	kcclient.APIResponseCommon


### PR DESCRIPTION
This enable checks to stop early when the instance stops, without doing GET requests in parallel