### PR TITLE
fix(images): Revert deprecate using list endpoint

### DIFF
--- a/images/image_get.go
+++ b/images/image_get.go
@@ -38,7 +38,7 @@ func (c *client) Get(ctx context.Context, ids ...string) (*kcclient.ServiceRespo
 	}
 
 	resp := &kcclient.ServiceResponse[GetResponseItem]{}
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, bytes.NewReader(body), resp); err != nil {
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/list", bytes.NewReader(body), resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 

--- a/images/image_list.go
+++ b/images/image_list.go
@@ -16,7 +16,7 @@ import (
 // List implements ImagesService.
 func (c *client) List(ctx context.Context) (*kcclient.ServiceResponse[GetResponseItem], error) {
 	resp := &kcclient.ServiceResponse[GetResponseItem]{}
-	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint, nil, resp); err != nil {
+	if err := c.request.DoRequest(ctx, http.MethodGet, Endpoint+"/list", nil, resp); err != nil {
 		return nil, fmt.Errorf("performing the request: %w", err)
 	}
 


### PR DESCRIPTION
Turns out it's still needed, whoops.